### PR TITLE
Correct all references to "cells" #1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ One really helpful contribution you can make is to try out KiSS dolls from
 [Okatuworld](http://www.otakuworld.com/kiss) and see which ones work
 and which don't. I would look for dolls that are as simple as possible
 -- a single palette, a small wardrobe, no animations or special
-effects (no "FKiSS"). (Please be aware that many dolls on Otakuworld are 
+effects (no "FKiSS"). (Please be aware that many dolls on Otakuworld are
 not appropriate for children or even worksafe.)
 
 Try the doll you've chosen in a KiSS doll viewer like [GnomeKiSS for
@@ -67,7 +67,7 @@ If a supported set has a bug:
  * If the problem is visual, add a screenshot of the doll in a working viewer
    such as UltraKiSS or GnomeKiSS as well as a screenshot of the problem in
    Smooch.
-   
+
 If the doll is small and has lots of interesting problems, it
 may be a good candidate for being included in the repo as a
 sample doll.
@@ -92,7 +92,7 @@ Pick an [issue](https://github.com/emhoracek/smooch/issues), or below are some m
 
 Please comment on the issue you want to work on to claim it *before* you start
 work. That way you can take your time working instead of racing to get the first
-pull request in. 
+pull request in.
 
 Don't see an interesting issue, or all the issues are claimed? Below are some more ideas. If any looks interesting, please create an issue for it so we can discuss different approaches and so other people can know that you're working on it.
 
@@ -115,7 +115,7 @@ Smooch.
    * Artists can select cels from the cel sheet and name them
    * Artists can insert cels into a set
    * Artists can group cels into objects
-   * Artists can save a set 
+   * Artists can save a set
    * Artists can publish sets to share with others
 
 The ones marked with a `*` will need some work on the backend as well.
@@ -146,6 +146,8 @@ Please make sure you have the following general software installed
 | ✔ | [stack](https://docs.haskellstack.org/en/stable/README/#the-haskell-tool-stack)  | >= 1.5.1 | `stack` is a Haskell dependency management tool |
 | ✔ | [Netpbm](http://brewformulas.org/Netpbm)  | >= 10.73.14 | Netpbm is a toolkit for manipulation of graphic images, including conversion of images between a variety of different formats |
 |  | [Homebrew](https://brew.sh/)  | >= 1.3.4 | Homebrew is the missing package manager for macOS |
+|  | [lhasa](https://fragglet.github.io/lhasa/) |  | Lhasa decompresses .lzh (LHA / LHarc) and .lzs (LArc) archives |
+
 
 ### Install `GCC`
 
@@ -168,6 +170,10 @@ This is how the images are converted from the *.pnm format that `cel2pnm` create
 Following the [Homebrew install guide here](https://brew.sh/).
 * Open your terminal, copy and paste this command into your Terminal:
 `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+
+### Install `lhasa`
+
+* On Mac OSX you can use `Homebrew` to install `lhasa`, copy and past this command into your Terminal: `brew install lhasa`
 
 ## Project setup
 
@@ -230,7 +236,7 @@ gcc cel2pnm.c -o cel2pnm
 ### Install `stack`
 
 You'll need `stack` to build Smooch. [`stack`](https://github.com/commercialhaskell/stack) is a Haskell dependency management
-tool (kinda like `npm` for JavaScript). 
+tool (kinda like `npm` for JavaScript).
 
 * Following the `stack` [install guide here](https://docs.haskellstack.org/en/stable/README/#how-to-install)
 * Copy and paste this command into your Terminal:
@@ -241,7 +247,7 @@ curl -sSL https://get.haskellstack.org/ | sh
 
 ![alt text](https://preview.ibb.co/cYhc8w/install_stack.png "Install stack")
 
-* Once you have `stack` installed, change to the `app` directory and run `stack setup`. 
+* Once you have `stack` installed, change to the `app` directory and run `stack setup`.
 This will install the correct Haskell version (this will take a while if you don't already have it).
 
 ![alt text](https://preview.ibb.co/dNNoFb/stack_setup.png "stack setup")

--- a/app/templates/kissSet.tpl
+++ b/app/templates/kissSet.tpl
@@ -38,7 +38,7 @@
     </div>
 
     <div id="footer">
-      <p>All sets are © their original artists. Learn more about Smooch <a href="https://github.com/emhoracek/smooch">from the Github repo</a>.</p>
+      <p>All sets are © their original artists. Learn more about Smooch <a href="https://github.com/emhoracek/smooch" target="_blank">from the Github repo</a>.</p>
     </div>
 
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,13 +28,13 @@
     <p>Eventually Smooch will be a web app that allows anyone to view any set. For now I'm just running it on my machine and generating the JavaScript, HTML, and images. Whenever I get a set working, I'll upload it here.</p>
 
     <ul>
-      <li><a href="example-sets/arwen/">Arwen</a> by Aragonite and Anime Craze (2003) (<a href="http://otakuworld.com/kiss/dolls/pages/a/arwen.htm">on Otakuworld</a>)</li>
-      <li><a href="example-sets/aurora/">Aurora</a> by Punky (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/a/aurora.htm">on Otakuworld</a>) -- this doll has snap-to and animation effects in the original which aren't reproduced here</li>
-      <li><a href="example-sets/hyad/">Hyacinth Delilah</a> by Dorothy (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/h/hyad.htm">on Otakuworld</a>)</li>
-      <li><a href="example-sets/cquistis/">Quistis Trepe</a> by Chann (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/c/cquistis.htm">on Otakuworld</a>)</li>
-      <li><a href="example-sets/washua/">Little Washu</a> by Alison (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/w/washua.htm">on Otakuworld</a>)</li>
-      <li><a href="example-sets/sk_kimux/">Mini-Skuld</a> by MUX (1993) (<a href="http://otakuworld.com/kiss/dolls/pages/s/sk_kimux.htm">on Otakuworld</a>)</li>
-      <li><a href="example-sets/yura/">Sakasagami no Yura</a> by Kimiki (2000) (<a href="http://otakuworld.com/index.html?/kiss/dolls/?/kiss/dolls/pages/y/yura.htm">on Otakuworld</a>)</li>
+      <li><a href="example-sets/arwen/index.html">Arwen</a> by Aragonite and Anime Craze (2003) (<a href="http://otakuworld.com/kiss/dolls/pages/a/arwen.htm">on Otakuworld</a>)</li>
+      <li><a href="example-sets/aurora/index.html">Aurora</a> by Punky (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/a/aurora.htm">on Otakuworld</a>) -- this doll has snap-to and animation effects in the original which aren't reproduced here</li>
+      <li><a href="example-sets/hyad/index.html">Hyacinth Delilah</a> by Dorothy (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/h/hyad.htm">on Otakuworld</a>)</li>
+      <li><a href="example-sets/cquistis/index.html">Quistis Trepe</a> by Chann (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/c/cquistis.htm">on Otakuworld</a>)</li>
+      <li><a href="example-sets/washua/index.html">Little Washu</a> by Alison (2001) (<a href="http://otakuworld.com/kiss/dolls/pages/w/washua.htm">on Otakuworld</a>)</li>
+      <li><a href="example-sets/sk_kimux/index.html">Mini-Skuld</a> by MUX (1993) (<a href="http://otakuworld.com/kiss/dolls/pages/s/sk_kimux.htm">on Otakuworld</a>)</li>
+      <li><a href="example-sets/yura/index.html">Sakasagami no Yura</a> by Kimiki (2000) (<a href="http://otakuworld.com/index.html?/kiss/dolls/?/kiss/dolls/pages/y/yura.htm">on Otakuworld</a>)</li>
     </ul>
   </main>
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,9 +1,40 @@
 # Contents
 
+  * [Running this website on a local server](#local-server)
   * [JavaScript front-end](#javascript-front-end)
     * [doll.js](#dolljs)
     * [setdata.js](#setdatajs)
   * [reader.html and reader.js](#readerhtml-and-readerjs)
+
+# Running this website on a local server
+
+Due to [cross-origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), this website should be ran on a local server for proper testing in Chrome or Safari.  If index.html is opened directly, you may see an error like:
+```
+Uncaught DOMException: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The canvas has been tainted by cross-origin data.
+```
+Note that in Firefox this error may not occur.
+Two possible servers to implement are Python Simple Server and Node-Http Server
+
+## Python Simple Server (preferred for python or non-javascript users)
+Follow the instructions at [this link](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server) for set up.
+
+## Node-Http Server (preferred for javascript users)
+First, [install node.js](https://nodejs.org/en/) 
+
+Then, follow the instructions at [this link](https://www.npmjs.com/package/http-server) for set up.
+
+### Running the server
+Change your directory from the project root to the docs folder
+```
+cd docs
+```
+
+Start up your local server using your preferred choice (python or node - follow the instructions in the appropriate link above)
+
+Once server is running, navigate to the port in your browser (your port may be different depending on set up)
+```
+localhost:3000
+```
 
 # JavaScript front-end
 

--- a/javascript/doll.js
+++ b/javascript/doll.js
@@ -66,20 +66,36 @@ KissSet.prototype = {
         };
 
 
+
         /* Go through each KiSS object, add information from the object to the
            cells within the object, then add those cells to the list. */
+
+        var red = 0;
+        var blue = 0;
+        var green = 0;
+
         for (var i = 0; i < objs.length; i++) {
             var objid = objs[i].id;
 
             // create a unique color for each obj based on the obj id
             // and register it in the global colorids array
-            // TODO: Handle ids larger than 255
-            //       Need to map each integer to a unique color
-            if (i < 255) {
-                var colorid = i + 0 + 0 + 255;
-                colorids[colorid] = i;
-                objs[i].color = { red: i, green: 0, blue: 0, alpha: 255 };
+            // supports up to 255*3 objects
+            if (i < 255){
+                red = i;
             }
+            else if ((i > 255) && (i < 255*2)){
+                red = 0;
+                green = i;
+            }
+            else if ((i > 255*2) && (i < 255*3)){
+                green = 0;
+                blue = i;
+            }
+            
+            var colorid = red + green + blue + 255;
+            colorids[colorid] = i;
+            objs[i].color = { red: red, green: green, blue: blue, alpha: 255 };
+            
 
             // now lets go through the cels
             var obj_cells = objs[i].cells;

--- a/javascript/doll.js
+++ b/javascript/doll.js
@@ -5,10 +5,6 @@ var loaded = 0;
 
 var Smooch = function(kissData) {
 
-    this.editMode = false;
-
-    var editButton = document.getElementById("edit");
-
     this.set = new KissSet(kissData);
     this.set.update();
     this.set.draw();

--- a/javascript/doll.js
+++ b/javascript/doll.js
@@ -379,7 +379,6 @@ var Mouser = function(that) {
 window.addEventListener('load', function() {
     var kissData = kissJson;
     this.smooch = new Smooch(kissData);
-    var blah = 0;
     var checkLoaded = function () {
         if (loaded < kissData.cels.length) {
             console.log("loading...");

--- a/javascript/kiss.html
+++ b/javascript/kiss.html
@@ -220,7 +220,7 @@
       </div>
 
       <div id="footer">
-        <p>All sets are © their original artists. Learn more about Smooch <a href="https://github.com/emhoracek/smooch">from the Github repo</a>.</p>
+        <p>All sets are © their original artists. Learn more about Smooch <a href="https://github.com/emhoracek/smooch" target="_blank">from the Github repo</a>.</p>
       </div>
 
     </div>


### PR DESCRIPTION
Fixes  #\<1\>.

All references to cells are changed to cel or  #cels.

There are two files that read `parseCelLine`. I did not further edit this to remove extra L.
app/src/ParseCNF.hs and app/tests/ParseCNFSpec.hs

Please let me know if further edits are needed for this issue and I will make them accordingly.
